### PR TITLE
docs : comment 관련 수정

### DIFF
--- a/src/main/java/likelion/ideateam3/happy_board/config/SecurityConfig.java
+++ b/src/main/java/likelion/ideateam3/happy_board/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,6 +26,13 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
+        hierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");
+        return hierarchy;
+    }
+
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, TokenProvider tokenProvider, AuthenticationManager authenticationManager) throws Exception {
@@ -34,7 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers(HttpMethod.POST, "/api/members/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/login").permitAll()
-                        // TODO. 요청별 권한 맞게 추가
+                        .requestMatchers("/api/board/comment/**").hasAnyRole("USER")
                         .anyRequest().hasRole("ADMIN"))
                 .addFilterBefore(new JwtAuthenticationFilter(tokenProvider, authenticationManager), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(e -> e

--- a/src/main/java/likelion/ideateam3/happy_board/config/SecurityConfig.java
+++ b/src/main/java/likelion/ideateam3/happy_board/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers(HttpMethod.POST, "/api/members/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members/login").permitAll()
+                        // TODO. 요청별 권한 맞게 추가
                         .requestMatchers("/api/board/comment/**").hasAnyRole("USER")
                         .anyRequest().hasRole("ADMIN"))
                 .addFilterBefore(new JwtAuthenticationFilter(tokenProvider, authenticationManager), UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
# ✨ PR 세부 내용 
## add :  
- config : comment API 접근 권한 설정
    - get : 접근제한없음
    - post , delete , patch : USER 이상 권한만 접근 가능 
   
## refactor : 
- controller :  불필요한 Long memberId 파라미터 삭제
- dto :  불필요한 private Long memberId 필드 삭제
- service : securityContext 에 저장된 인증객체를 활용해 memberId 를 얻어냄
