### PR TITLE
docs : 프론트 요구 따른 comment 반환 결과 수정

### DIFF
--- a/src/main/java/likelion/ideateam3/happy_board/controller/comment/CommentController.java
+++ b/src/main/java/likelion/ideateam3/happy_board/controller/comment/CommentController.java
@@ -3,7 +3,8 @@ package likelion.ideateam3.happy_board.controller.comment;
 
 
 import jakarta.validation.Valid;
-import likelion.ideateam3.happy_board.dto.CommentDTO;
+import likelion.ideateam3.happy_board.dto.CommentRequestDTO;
+import likelion.ideateam3.happy_board.dto.CommentResponseDTO;
 import likelion.ideateam3.happy_board.response.ResponseBody;
 import likelion.ideateam3.happy_board.response.ResponseUtil;
 import likelion.ideateam3.happy_board.service.comment.CommentService;
@@ -31,15 +32,15 @@ public class CommentController {
     }
 
     @GetMapping("/comments/{boardId}")
-    public ResponseEntity<ResponseBody<List<CommentDTO>>> getCommentsById(@PathVariable Long boardId ){
-            List<CommentDTO>  response = commentService.getCommentsById(boardId);
+    public ResponseEntity<ResponseBody<List<CommentResponseDTO>>> getCommentsById(@PathVariable Long boardId ){
+            List<CommentResponseDTO>  response = commentService.getCommentsById(boardId);
 
         return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse(response));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ResponseBody<List<CommentDTO>>> getChildCommentsById(@PathVariable Long id ){
-        List<CommentDTO>  response = commentService.getChildCommentsById(id);
+    public ResponseEntity<ResponseBody<List<CommentResponseDTO>>> getChildCommentsById(@PathVariable Long id ){
+        List<CommentResponseDTO>  response = commentService.getChildCommentsById(id);
         return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse(response));
     }
 
@@ -48,22 +49,22 @@ public class CommentController {
 
 
     @PostMapping("")
-    public ResponseEntity<ResponseBody<CommentDTO>> createComment( @Valid @RequestBody CommentDTO dto){
+    public ResponseEntity<ResponseBody<CommentResponseDTO>> createComment(@Valid @RequestBody CommentRequestDTO dto){
 
 
 // 멤버 정보를 따로 받지 않고 SecurityContext 에 저장된 authentication 객체를 활용
 
 
-            CommentDTO createdDto = commentService.createComment(dto);
+        CommentResponseDTO createdDto = commentService.createComment(dto);
 
         return ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse(createdDto));
     }
 
 
     @PatchMapping("/{id}")
-    public ResponseEntity<ResponseBody<CommentDTO>> patchComment(@PathVariable Long id,@Valid @RequestBody CommentDTO dto){
+    public ResponseEntity<ResponseBody<CommentResponseDTO>> patchComment(@PathVariable Long id, @Valid @RequestBody CommentRequestDTO dto){
         log.info(id+", "+dto);
-        CommentDTO updated = commentService.patchComment(id, dto);
+        CommentResponseDTO updated = commentService.patchComment(id, dto);
         return   ResponseEntity.status(HttpStatus.OK) .body(ResponseUtil.createSuccessResponse(updated));
     }
 

--- a/src/main/java/likelion/ideateam3/happy_board/domain/comment/Comment.java
+++ b/src/main/java/likelion/ideateam3/happy_board/domain/comment/Comment.java
@@ -5,13 +5,10 @@ import jakarta.validation.constraints.PositiveOrZero;
 import likelion.ideateam3.happy_board.domain.board.Board;
 import likelion.ideateam3.happy_board.domain.common.BaseEntity;
 import likelion.ideateam3.happy_board.domain.member.Member;
-import likelion.ideateam3.happy_board.dto.CommentDTO;
-import likelion.ideateam3.happy_board.response.exception.BusinessException;
-import likelion.ideateam3.happy_board.response.exception.ExceptionType;
+import likelion.ideateam3.happy_board.dto.CommentRequestDTO;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +66,7 @@ public class Comment extends BaseEntity {
     // DTO 에 정의한 toEntity 와는 별개로 생성
     // dto 의 toEntity 는 dto 정보만을 기반으로 entity 를 생성하는 것
     // 이번에 정의한 것은 db 기반으로 만드는 것
-    public static Comment createEntityWithDto(CommentDTO dto, Board board , Member member , Comment parent) {
+    public static Comment createEntityWithDto(CommentRequestDTO dto, Board board , Member member , Comment parent) {
 
         // 엔티티 생성 불가한 경우는 컨트롤러 단의 @Valid 가 알아서 거른다
        
@@ -78,7 +75,7 @@ public class Comment extends BaseEntity {
         return comment;
     }
 
-    public void patch(CommentDTO dto){ // CommentService 의 patch 전용
+    public void patch(CommentRequestDTO dto){ // CommentService 의 patch 전용
         if(dto.getContent() !=null) this.content = dto.getContent();
         if(dto.getLikes() !=null) this.likes = dto.getLikes();
     }

--- a/src/main/java/likelion/ideateam3/happy_board/dto/CommentRequestDTO.java
+++ b/src/main/java/likelion/ideateam3/happy_board/dto/CommentRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 @NoArgsConstructor
 @AllArgsConstructor
 @Slf4j
-public class CommentDTO {
+public class CommentRequestDTO {
 
 
     private Long id;
@@ -24,8 +24,8 @@ public class CommentDTO {
         return entity;
     }
 
-    public static CommentDTO toDTO(Comment comment){
-        return  new CommentDTO(comment.getId(), comment.getBoard().getId()
+    public static CommentRequestDTO toDTO(Comment comment){
+        return  new CommentRequestDTO(comment.getId(), comment.getBoard().getId()
                 ,  comment.getParent() ==null ? null: comment.getParent().getId()
                 ,  comment.getContent(), comment.getLikes());
     }

--- a/src/main/java/likelion/ideateam3/happy_board/dto/CommentResponseDTO.java
+++ b/src/main/java/likelion/ideateam3/happy_board/dto/CommentResponseDTO.java
@@ -1,0 +1,33 @@
+package likelion.ideateam3.happy_board.dto;
+
+import likelion.ideateam3.happy_board.domain.comment.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Slf4j
+public class CommentResponseDTO {
+
+
+    private Long id;
+    private Long boardId;
+    private Long memberId;
+    private String nickname;
+    private Long parentId;
+    private String content;
+    private Integer likes;
+
+
+
+    public static CommentResponseDTO toDTO(Comment comment){
+        return  new CommentResponseDTO(comment.getId(), comment.getBoard().getId(), comment.getMember().getId()
+                ,comment.getMember().getNickname()
+                ,  comment.getParent() ==null ? null: comment.getParent().getId()
+                ,  comment.getContent(), comment.getLikes());
+    }
+
+}

--- a/src/main/java/likelion/ideateam3/happy_board/service/comment/CommentService.java
+++ b/src/main/java/likelion/ideateam3/happy_board/service/comment/CommentService.java
@@ -5,7 +5,8 @@ import likelion.ideateam3.happy_board.domain.board.Board;
 import likelion.ideateam3.happy_board.domain.comment.Comment;
 import likelion.ideateam3.happy_board.domain.member.Member;
 import likelion.ideateam3.happy_board.domain.member.MemberPrincipal;
-import likelion.ideateam3.happy_board.dto.CommentDTO;
+import likelion.ideateam3.happy_board.dto.CommentRequestDTO;
+import likelion.ideateam3.happy_board.dto.CommentResponseDTO;
 import likelion.ideateam3.happy_board.repository.board.BoardRepository;
 import likelion.ideateam3.happy_board.repository.comment.CommentRepository;
 import likelion.ideateam3.happy_board.repository.member.MemberRepository;
@@ -36,20 +37,20 @@ public class CommentService {
     }
 
 
-    public List<CommentDTO> getCommentsById(Long boardId) {
+    public List<CommentResponseDTO> getCommentsById(Long boardId) {
         List<Comment> entityList= commentRepository.findByBoardId(boardId);
-        List<CommentDTO> dtoList = entityList.stream().map(entity->CommentDTO.toDTO(entity)).collect(Collectors.toList());
+        List<CommentResponseDTO> dtoList = entityList.stream().map(entity-> CommentResponseDTO.toDTO(entity)).collect(Collectors.toList());
         return dtoList;
     }
 
-    public List<CommentDTO> getChildCommentsById(Long id) {
+    public List<CommentResponseDTO> getChildCommentsById(Long id) {
         List<Comment> entityList= commentRepository.findByParentId(id);
-        List<CommentDTO> dtoList = entityList.stream().map(entity->CommentDTO.toDTO(entity)).collect(Collectors.toList());
+        List<CommentResponseDTO> dtoList = entityList.stream().map(entity-> CommentResponseDTO.toDTO(entity)).collect(Collectors.toList());
         return dtoList;
     }
 
     @Transactional
-    public CommentDTO createComment(CommentDTO dto) {
+    public CommentResponseDTO createComment(CommentRequestDTO dto) {
         log.info("createComment-input >> "+dto.toString());
 
         // 1. 해당 postId 를 가지는 게시글이 존재하는지 우선 검색
@@ -79,14 +80,14 @@ public class CommentService {
         // 4. 댓글 엔티티 생성
         Comment comment = Comment.createEntityWithDto(dto, board, member ,parentComment );
         Comment created = commentRepository.save(comment);
-        return CommentDTO.toDTO(created);
+        return CommentResponseDTO.toDTO(created);
     }
 
 
 
 
     @Transactional
-    public CommentDTO patchComment(Long id, CommentDTO dto) {
+    public CommentResponseDTO patchComment(Long id, CommentRequestDTO dto) {
         // 1. 해당 id 를 가지는 댓글이 존재하는지 우선 검색
         Comment comment = commentRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ExceptionType.COMMENT_NOT_FOUND_ERROR));
@@ -96,7 +97,7 @@ public class CommentService {
         comment.patch(dto);
         log.info("patchComment >> " + comment);
 
-        return CommentDTO.toDTO(comment);
+        return CommentResponseDTO.toDTO(comment);
     }
 
     @Transactional


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] add : ~
-->

## ✨ PR 세부 내용
- add : member 의 id 와 nickname 까지 함께 반환할 수 있도록 CommentResponseDto추가 
- docs  : 조회할 땐 여전히 member 의 id 를 따로 받을 필요 없게하기 위해(securitycontextholder 에서 가져옴) 기존 CommentDto를 CommentRequestDto 로 수정

<!-- 수정/추가한 내용을 적어주세요. -->
